### PR TITLE
MousePosition and PreviousMousePosition set property is now private.

### DIFF
--- a/Jeden/Engine/InputManager.cs
+++ b/Jeden/Engine/InputManager.cs
@@ -23,8 +23,8 @@ namespace Jeden.Engine
 
         //public int DeltaScrollWheel { get; set; } //not really needed
 
-        public Vector2i MousePosition { get; set; }
-        public Vector2i PreviousMousePosition { get; set; }
+        public Vector2i MousePosition { get; private set; }
+        public Vector2i PreviousMousePosition { get; private set; }
 
         public InputManager(GameEngine engine) 
         {


### PR DESCRIPTION
Regarding my enhancement issue: 
Publicly Modifiable MousePosition #2

This commit enhance what I discussed, making both variables setters private.
